### PR TITLE
Extended angular component to nearly full croppie API

### DIFF
--- a/angular-croppie.js
+++ b/angular-croppie.js
@@ -1,34 +1,59 @@
-angular.module('angularCroppie', []).
+(function() {
+
+  "use strict";
+
+  angular.module('angularCroppie', []).
   component('croppie', {
+    controller: AngularCroppie,
     bindings: {
       src: '<',
-      ngModel: '='
-    },
-    controller: function ($scope, $element) {
-      var ctrl = this;
-
-      var c = new Croppie($element[0], {
-        viewport: {
-          width: 200,
-          height: 200
-        },
-        update: function () {
-          c.result('canvas').then(function(img) {
-            $scope.$apply(function () {
-              ctrl.ngModel = img;
-            });
-          });
-        }
-      });
-
-      ctrl.$onChanges = function (changesObj) {
-        var src = changesObj.src && changesObj.src.currentValue;
-        if(src) {
-          // bind an image to croppie
-          c.bind({
-            url: src
-          });
-        }
-      };
+      ngModel: '=',
+      onChange: '&',
+      options: '@',
+      resultConfig: '<'
     }
   });
+  AngularCroppie.$inject = ['$scope', '$element'];
+
+
+  /*@ngInject*/
+  function AngularCroppie($scope, $element) {
+    var ctrl = this;
+    var c;
+
+
+
+    ctrl.$onInit = function() {
+      //Append/Override update method in 
+      vm.options.update = onCroppieUpdate;
+      c = new Croppie($element[0],
+        vm.options);
+    };
+
+    ctrl.$onChanges = function(changesObj) {
+      var src = changesObj.src && changesObj.src.currentValue;
+      if (src) {
+        // bind an image to croppie
+        c.bind({
+          url: src
+        });
+      }
+    };
+
+    ctrl.$onDestroy = function() {
+      if (c) {
+        c.destroy();
+      }
+    };
+
+
+    function onCroppieUpdate() {
+      c.result(vm.resultConfig).then(function(img) {
+        $scope.$apply(function() {
+          ctrl.ngModel = img;
+        });
+      });
+    }
+  }
+
+})();

--- a/angular-croppie.js
+++ b/angular-croppie.js
@@ -25,9 +25,6 @@
 
     ctrl.$onInit = function() {
       if (!c) {
-        ctrl.options.update = onCroppieUpdate;
-        c = new Croppie($element[0],
-          ctrl.options);
 
         var changesObj = {};
         if (ctrl.src) {
@@ -60,8 +57,8 @@
     };
 
     ctrl.$onChanges = function(changesObj) {
-      if (!c) {
-        ctrl.$onInit();
+      if (!c && (changesObj.bindConfig || changesObj.src)) {
+        initCroppie();
       }
       if (changesObj.bindConfig) {
         var bindConf = changesObj.bindConfig.currentValue || {};
@@ -101,16 +98,27 @@
     };
 
     function onCroppieUpdate() {
-      c.result(ctrl.resultConfig).then(function(img) {
-        $scope.$apply(function() {
-          ctrl.ngModel = img;
+      if (c) {
+        c.result(ctrl.resultConfig).then(function(img) {
+          $scope.$apply(function() {
+            ctrl.ngModel = img;
+          });
+          ctrl.onChange({
+            $event: {
+              model: ctrl.ngModel
+            }
+          });
         });
-        ctrl.onChange({
-          $event: {
-            model: ctrl.ngModel
-          }
-        });
-      });
+      }
+    }
+
+    function initCroppie() {
+
+      if (!c) {
+        ctrl.options.update = onCroppieUpdate;
+        c = new Croppie($element[0],
+          ctrl.options);
+      }
     }
   }
 

--- a/angular-croppie.js
+++ b/angular-croppie.js
@@ -12,7 +12,7 @@
       zoom: '<', // calls Croppie.setZoom(zoom) on change
       rotate: '<', // calls Croppie.rotate(rotate) on change
       bindConfig: '<', //calls Croppie.bind(bindConfig) on change
-      resultConfig: '<', //calls Croppie.result(resultConfig) on change (results in onChange being called) 
+      resultConfig: '<', //calls Croppie.result(resultConfig) on change (results in onChange being called)
       src: '<' // For simplifying bindConfig: it changes url in bindConfig then calls Croppie.bind(bindConfig)
     }
   });
@@ -28,6 +28,34 @@
         ctrl.options.update = onCroppieUpdate;
         c = new Croppie($element[0],
           ctrl.options);
+
+        var changesObj = {};
+        if (ctrl.src) {
+          changesObj.src = {
+            currentValue: ctrl.src
+          };
+        }
+        if (ctrl.zoom) {
+          changesObj.zoom = {
+            currentValue: ctrl.zoom
+          };
+        }
+        if (ctrl.rotate) {
+          changesObj.rotate = {
+            currentValue: ctrl.rotate
+          };
+        }
+        if (ctrl.bindConfig) {
+          changesObj.bindConfig = {
+            currentValue: ctrl.bindConfig
+          };
+        }
+        if (ctrl.resultConfig) {
+          changesObj.resultConfig = {
+            currentValue: ctrl.resultConfig
+          };
+        }
+        ctrl.$onChanges(changesObj);
       }
     };
 
@@ -54,9 +82,15 @@
         onCroppieUpdate();
       }
       if (changesObj.src) {
-        var src = changesObj.src.currentValue || {};
-        vm.bindConfig.url = src;
-        c.bind(vm.bindConfig);
+        var src = changesObj.src.currentValue || '';
+        if (ctrl.bindConfig) {
+          ctrl.bindConfig.url = src;
+        } else {
+          ctrl.bindConfig = {
+            url: src
+          };
+        }
+        c.bind(ctrl.bindConfig);
       }
     };
 


### PR DESCRIPTION
Hey,
there is an updated version of the angular component. It supports most of the Croppie API. As you can see there are some things still to be done, since it is far from complete, but I tought I throw it in just for some feedback. :smile_cat:  

TBD:
- Discuss if the component needs to be able to recreate Croppie component. Currently the configuration of the croppie component must be done on component initialzation. Maybe it should be delayed until a specific event.

- Get rid of two way component binding since it can be overwritten in the parent scope. The real problem is that it needs to be replaced with an on-demand result request method. (Maybe should be kept for backwards compatibility).

- Write proper documentation

- Proper multibrowser testing